### PR TITLE
Create a GitHub action for building and linting the application

### DIFF
--- a/src/.github/workflows/build-and-lint.yml
+++ b/src/.github/workflows/build-and-lint.yml
@@ -1,0 +1,31 @@
+name: Build and Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint code
+        run: npm run lint
+
+      - name: Build application
+        run: npm run build


### PR DESCRIPTION
Fixes #10

Add a GitHub action workflow for building and linting the application.

* Create a new workflow file `build-and-lint.yml` in the `.github/workflows/` directory.
* Trigger the workflow on `push` and `pull_request` events for the `main` branch.
* Set up Node.js using the `actions/setup-node@v2` action with Node.js version 14.
* Install dependencies using `npm install`.
* Lint the code using `npm run lint`.
* Build the application using `npm run build`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tankefugl/space-invaders/issues/10?shareId=e10bf384-48a5-45d6-acd3-8a088c5dee58).