### PR TITLE
Fix webpack configuration to serve index.html

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,13 @@ module.exports = {
     ],
   },
   devServer: {
-    contentBase: path.join(__dirname, 'dist'),
+    contentBase: path.join(__dirname, 'src'),
     compress: true,
     port: 9000,
+    before: function(app, server) {
+      app.get('/', function(req, res) {
+        res.sendFile(path.join(__dirname, 'src', 'index.html'));
+      });
+    },
   },
 };


### PR DESCRIPTION
Related to #15

Update webpack.config.js to serve the src/index.html file correctly.

* Change contentBase in devServer configuration from dist to src.
* Add a before function in devServer configuration to serve the src/index.html file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tankefugl/space-invaders/issues/15?shareId=d8b182f3-06e2-4c7d-94df-832ece97d669).