### PR TITLE
Kill enemies hit by the player projectiles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ function shootLaser() {
       laser.remove();
     } else {
       laser.style.bottom = `${currentBottom + 10}px`;
+      checkCollision(laser);
       requestAnimationFrame(moveLaserUp);
     }
   }
@@ -95,6 +96,25 @@ function moveEnemies() {
     enemyDirection *= -1;
     enemySpeed += 0.5;
   }
+}
+
+function checkCollision(laser) {
+  const laserRect = laser.getBoundingClientRect();
+  const enemies = document.querySelectorAll('.enemy');
+
+  enemies.forEach((enemy) => {
+    const enemyRect = enemy.getBoundingClientRect();
+
+    if (
+      laserRect.left < enemyRect.right &&
+      laserRect.right > enemyRect.left &&
+      laserRect.top < enemyRect.bottom &&
+      laserRect.bottom > enemyRect.top
+    ) {
+      laser.remove();
+      enemy.remove();
+    }
+  });
 }
 
 function gameLoop() {


### PR DESCRIPTION
Fixes #22

Add collision detection between player projectiles and enemies.

* Add `checkCollision` function to check for collisions between lasers and enemies.
* Modify `shootLaser` function to call `checkCollision` and remove both the laser and the enemy upon collision.
* Add call to `checkCollision` inside the `moveLaserUp` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tankefugl/space-invaders/issues/22?shareId=ab3eb9a1-7ec1-4cf6-b893-346a89ccb79c).