### PR TITLE
Fix bug in player movement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,8 @@ function handleKeyUp(event) {
 function moveLaserCannon(distance) {
   const laserCannon = document.querySelector('.laser-cannon');
   const currentLeft = parseInt(laserCannon.style.left || '50%', 10);
-  const newLeft = currentLeft + distance;
+  const currentLeftPixels = (currentLeft / 100) * gameContainer.clientWidth;
+  const newLeft = currentLeftPixels + distance;
   if (newLeft >= 0 && newLeft <= gameContainer.clientWidth - laserCannon.clientWidth) {
     laserCannon.style.left = `${newLeft}px`;
   }


### PR DESCRIPTION
Fixes #28

Fix the bug where the player jumps to the far left when an arrow is pressed.

* Update `moveLaserCannon` function in `src/index.js` to parse the laser cannon's current position as a pixel value instead of a percentage.
* Calculate the new position by converting the current position from percentage to pixels and adding the distance.
* Ensure the laser cannon's position is updated accordingly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tankefugl/space-invaders/issues/28?shareId=679cdd39-1bd6-489a-8268-807291294f51).